### PR TITLE
Fixed dictionary search bug

### DIFF
--- a/src/main/java/org/alouastudios/easytagalogbackend/repository/WordRepository.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/repository/WordRepository.java
@@ -24,7 +24,9 @@ public interface WordRepository extends JpaRepository<Word, Long> {
         WHERE LOWER(w.tagalog) = LOWER(:searchQuery)
         OR LOWER(w.root) = LOWER(:searchQuery)
         OR LOWER(e.meaning) = LOWER(:searchQuery)
-        OR LOWER(e.meaning) LIKE LOWER(CONCAT(:searchQuery, '%'))
+        OR LOWER(e.meaning) LIKE LOWER(CONCAT('% ', :searchQuery, ' %'))
+        OR LOWER(e.meaning) LIKE LOWER(CONCAT(:searchQuery, ' %'))
+        OR LOWER(e.meaning) LIKE LOWER(CONCAT('% ', :searchQuery))
     """)
     List<Word> findWordsBySearchQuery(@Param("searchQuery") String searchQuery);
 }

--- a/src/main/java/org/alouastudios/easytagalogbackend/service/WordService.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/service/WordService.java
@@ -105,7 +105,11 @@ public class WordService {
 
         return words.stream()
                 .map(word -> {
-                    boolean isExactMatch = word.getTagalog().equalsIgnoreCase(searchQuery);
+                    boolean isExactMatch = word.getTagalog().equalsIgnoreCase(searchQuery)
+                            || word.getTranslations().stream()
+                            .flatMap(translation -> translation.getEnglishMeanings().stream())
+                            .anyMatch(englishMeaning -> englishMeaning.getMeaning().equalsIgnoreCase(searchQuery));
+
                     List<PhraseResponseDTO> examplePhrases = isExactMatch
                             ? getExamplePhrases(word.getUuid())
                             : List.of();


### PR DESCRIPTION
There was 2 bugs:
- Searching "me" return "Ako" (meaning "me") but also "naman" (meaning "meanwhile"). Needed a more specific sql query to not search for substrings but rather tokens of a string (checked for spaces).
- I made it so only exact matches show example phrases but right now it only worked for tagalog matches. If a user were to search "dog", "Aso" would be returned but no example phrases. So I changed it to show for exact matches of tagalog and english. May need to revisit later.