### PR TITLE
feat: create new endpoint for fetching all lesson uuid + title

### DIFF
--- a/src/main/java/org/alouastudios/easytagalogbackend/controller/LessonController.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/controller/LessonController.java
@@ -4,6 +4,7 @@ import org.alouastudios.easytagalogbackend.dto.lesson.CheckAnswerRequest;
 import org.alouastudios.easytagalogbackend.dto.lesson.CheckAnswerResponse;
 import org.alouastudios.easytagalogbackend.dto.lesson.LessonRequestDTO;
 import org.alouastudios.easytagalogbackend.dto.lesson.LessonResponseDTO;
+import org.alouastudios.easytagalogbackend.dto.lesson.LessonSummaryDTO;
 import org.alouastudios.easytagalogbackend.service.LessonService;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +23,9 @@ public class LessonController {
 
     @GetMapping
     public List<LessonResponseDTO> getAllLessons() { return lessonService.getAllLessons(); }
+
+    @GetMapping("/summary")
+    public List<LessonSummaryDTO> getLessonSummaries() { return lessonService.getLessonSummaries(); }
 
     @GetMapping("/{uuid}")
     public LessonResponseDTO getLessonById(@PathVariable UUID uuid) { return lessonService.getLessonByUUID(uuid); }

--- a/src/main/java/org/alouastudios/easytagalogbackend/dto/lesson/LessonResponseDTO.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/dto/lesson/LessonResponseDTO.java
@@ -1,7 +1,6 @@
 package org.alouastudios.easytagalogbackend.dto.lesson;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 public record LessonResponseDTO(

--- a/src/main/java/org/alouastudios/easytagalogbackend/dto/lesson/LessonSummaryDTO.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/dto/lesson/LessonSummaryDTO.java
@@ -1,0 +1,9 @@
+package org.alouastudios.easytagalogbackend.dto.lesson;
+
+import java.util.UUID;
+
+public record LessonSummaryDTO(
+        UUID uuid,
+        String title
+) {
+}

--- a/src/main/java/org/alouastudios/easytagalogbackend/service/LessonService.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/service/LessonService.java
@@ -39,6 +39,13 @@ public class LessonService {
                 .toList();
     }
 
+    public List<LessonSummaryDTO> getLessonSummaries() {
+        return lessonRepository.findAll()
+                .stream()
+                .map(lesson -> new LessonSummaryDTO(lesson.getUuid(), lesson.getTitle()))
+                .toList();
+    }
+
     public LessonResponseDTO getLessonByUUID(UUID uuid) {
         Lesson foundLesson = lessonRepository
                 .findByUuid(uuid)


### PR DESCRIPTION
## Description

The frontend needed a way to display all lessons for the user to choose. Although there was an endpoint to fetch all lessons, it fetched all lessons plus all of its items (questions). That is a very heavy request especially for the "Learn" page that just needed to show titles of the lessons.

This PR creates an endpoint to fetch all lessons but only its UUID + title.


## Docs

Created LessonSummaryDTO which just has a uuid and title.