### PR TITLE
feat: add isPublished field to lessons to filter learn page endpoint

### DIFF
--- a/src/main/java/org/alouastudios/easytagalogbackend/dto/lesson/LessonRequestDTO.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/dto/lesson/LessonRequestDTO.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record LessonRequestDTO(
     String title,
+    Boolean isPublished,
     List<LessonItemRequestDTO> items
 ) {
 }

--- a/src/main/java/org/alouastudios/easytagalogbackend/dto/lesson/LessonResponseDTO.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/dto/lesson/LessonResponseDTO.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 public record LessonResponseDTO(
         UUID uuid,
         String title,
+        boolean isPublished,
         List<LessonItemResponseDTO> items
 ) {
 }

--- a/src/main/java/org/alouastudios/easytagalogbackend/mapper/LessonMapper.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/mapper/LessonMapper.java
@@ -24,12 +24,14 @@ public class LessonMapper {
         return new LessonResponseDTO(
                 lesson.getUuid(),
                 lesson.getTitle(),
+                lesson.isPublished(),
                 lesson.getItems().stream().map(this::toLessonQuestionResponseDTO).collect(Collectors.toList())
         );
     }
 
     public void toEntity(Lesson lesson, LessonRequestDTO lessonRequestDTO, List<LessonItem> lessonItems) {
         lesson.setTitle(lessonRequestDTO.title());
+        lesson.setPublished(lessonRequestDTO.isPublished() != null ? lessonRequestDTO.isPublished() : true);
 
         lesson.getItems().clear();
         lesson.getItems().addAll(lessonItems);

--- a/src/main/java/org/alouastudios/easytagalogbackend/model/lessons/Lesson.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/model/lessons/Lesson.java
@@ -21,6 +21,9 @@ public class Lesson {
     @Column(unique = true, nullable = false)
     private String title;
 
+    @Column(nullable = false)
+    private boolean isPublished = true;
+
     @OneToMany(mappedBy = "lesson", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderColumn(name = "item_order")
     private List<LessonItem> items = new ArrayList<>();

--- a/src/main/java/org/alouastudios/easytagalogbackend/repository/LessonRepository.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/repository/LessonRepository.java
@@ -3,9 +3,11 @@ package org.alouastudios.easytagalogbackend.repository;
 import org.alouastudios.easytagalogbackend.model.lessons.Lesson;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface LessonRepository extends JpaRepository<Lesson, Long> {
     Optional<Lesson> findByUuid(UUID uuid);
+    List<Lesson> findAllByIsPublishedTrue();
 }

--- a/src/main/java/org/alouastudios/easytagalogbackend/service/LessonService.java
+++ b/src/main/java/org/alouastudios/easytagalogbackend/service/LessonService.java
@@ -40,7 +40,7 @@ public class LessonService {
     }
 
     public List<LessonSummaryDTO> getLessonSummaries() {
-        return lessonRepository.findAll()
+        return lessonRepository.findAllByIsPublishedTrue()
                 .stream()
                 .map(lesson -> new LessonSummaryDTO(lesson.getUuid(), lesson.getTitle()))
                 .toList();


### PR DESCRIPTION
## Description

The original endpoint fetched all lessons including the demo lesson. The endpoint for fetching lesson summaries is used for logged in users in their dashboard. The demo lesson shouldn't be shown on user dashboard. 

Added in a `isPublished` field to the Lesson entity which is default to `True` and set the demo lesson to `False`. The lesson summary endpoint only fetches lessons that have `isPublished` set to `True`.

I have migrated existing lessons to include this new `isPublished` column as well.

## Tests

Tested on postman and fetches correctly (no demo lesson).